### PR TITLE
Upgrade leinjacker from 0.4.0 to 0.4.1.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
   :url "https://github.com/flatland/protobuf"
   :dependencies [[fs "1.2.0"]
                  [conch "0.2.0"]
-                 [leinjacker "0.4.0"]]
+                 [leinjacker "0.4.1"]]
   :eval-in-leiningen true
   ;; Bug in the current 1.x branch of Leiningen causes
   ;; jar to implicitly clean no matter what, wiping stuff.


### PR DESCRIPTION
Version 0.4.0 of leinjacker is too restrictive on validity checks on incoming project.clj maps.
