### PR TITLE
Enable containing projects to propagate :javac-options

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lein-protobuf "0.4.1"
+(defproject org.pingles/lein-protobuf "0.4.2-SNAPSHOT"
   :description "Leiningen plugin for compiling protocol buffers."
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}

--- a/src/leiningen/protobuf.clj
+++ b/src/leiningen/protobuf.clj
@@ -131,7 +131,8 @@
                    (abort "ERROR:" (sh/stream-to-string result :err))))))
            (javac (assoc project
                     :java-source-paths [(.getPath dest)]
-                    :javac-options ["-Xlint:none"])))))))
+                    :javac-options (conj (or (:javac-options project) [])
+                                         "-Xlint:none"))))))))
 
 (defn compile-google-protobuf
   "Compile com.google.protobuf.*"


### PR DESCRIPTION
Hi,

We have some code which needs to target Java 1.6- if we use a 1.7 JDK the protocol buffers don't have the same options passed as the project they're contained within.

Thanks,
Paul
