### PR TITLE
Subprocess error handling

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :url "https://github.com/flatland/protobuf"
   :dependencies [[fs "1.2.0"]
-                 [conch "0.2.0"]
+                 [me.raynes/conch "0.6.0"]
                  [leinjacker "0.4.0"]]
   :eval-in-leiningen true
   ;; Bug in the current 1.x branch of Leiningen causes


### PR DESCRIPTION
There're plenty of things that can go wrong during the compilation of protobuf:
- Missing c++ compiler (but with the C and gcc preprocessor installed)
- this [issue](http://code.google.com/p/open-lighting/issues/detail?id=52)
- `javax.tools.ToolProvider/getSystemJavaCompiler` will yield `nil` (even if the OpenJDK is installed and javac is in the PATH... I get this issue on Fedora but not on Ubuntu)

thus, it'd be better to fail fast and report errors when they happen.

lein-protobuf currently doesn't even output at all the stderr of `./configure` and `make`.

The first commit does it, but by printing the commands output when they exit. In the second commit I updated `conch`, but there seems to still be some issues with the output buffering and the change is slightly more invasive.

I chose to avoid printing the stderr right away, and print it only at the end if the command failed, but maybe it'd be better to just print a generic error message after the full output.
