### PR TITLE
bumped up leinjacker to 0.4.2 to eliminate conflicts with other plugins

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
   :url "https://github.com/flatland/protobuf"
   :dependencies [[fs "1.2.0"]
                  [conch "0.2.0"]
-                 [leinjacker "0.4.0"]]
+                 [leinjacker "0.4.2"]]
   :eval-in-leiningen true
   ;; Bug in the current 1.x branch of Leiningen causes
   ;; jar to implicitly clean no matter what, wiping stuff.


### PR DESCRIPTION
While trying to use lein-protobuf alongside lein-autoexpect I encountered an error like the one below.

Bumping up the leinjacker version to 0.4.2 seems to fix it, hence this pull request. 

Exception in thread "main" java.lang.AssertionError: Assert failed: (vector? (:dependencies project []))
    at leinjacker.deps$add_if_missing.invoke(deps.clj:43)
    at leiningen.autoexpect$add_deps.invoke(autoexpect.clj:10)
    at leiningen.autoexpect$autoexpect.doInvoke(autoexpect.clj:27)
    at clojure.lang.RestFn.invoke(RestFn.java:410)
    at clojure.lang.Var.invoke(Var.java:379)
    at clojure.lang.AFn.applyToHelper(AFn.java:154)
    at clojure.lang.Var.applyTo(Var.java:700)
    at clojure.core$apply.invoke(core.clj:626)
    at leiningen.core.main$partial_task$fn__6071.doInvoke(main.clj:253)
    at clojure.lang.RestFn.invoke(RestFn.java:410)
    at clojure.lang.AFn.applyToHelper(AFn.java:154)
    at clojure.lang.RestFn.applyTo(RestFn.java:132)
    at clojure.lang.AFunction$1.doInvoke(AFunction.java:29)
    at clojure.lang.RestFn.applyTo(RestFn.java:137)
    at clojure.core$apply.invoke(core.clj:626)
    at leiningen.core.main$apply_task.invoke(main.clj:303)
    at lein_environ.plugin$write_env_to_file.invoke(plugin.clj:11)
    at clojure.lang.Var.invoke(Var.java:394)
    at clojure.lang.AFn.applyToHelper(AFn.java:165)
    at clojure.lang.Var.applyTo(Var.java:700)
    at clojure.core$apply.invoke(core.clj:626)
    at robert.hooke$compose_hooks$fn__11692.doInvoke(hooke.clj:40)
    at clojure.lang.RestFn.applyTo(RestFn.java:137)
    at clojure.core$apply.invoke(core.clj:624)
    at robert.hooke$run_hooks.invoke(hooke.clj:46)
    at robert.hooke$prepare_for_hooks$fn__11697$fn__11698.doInvoke(hooke.clj:54)
    at clojure.lang.RestFn.applyTo(RestFn.java:137)
    at clojure.lang.AFunction$1.doInvoke(AFunction.java:29)
    at clojure.lang.RestFn.invoke(RestFn.java:436)
    at leiningen.core.main$resolve_and_apply.invoke(main.clj:309)
    at leiningen.core.main$_main$fn__6136.invoke(main.clj:377)
    at leiningen.core.main$_main.doInvoke(main.clj:366)
    at clojure.lang.RestFn.invoke(RestFn.java:408)
    at clojure.lang.Var.invoke(Var.java:379)
    at clojure.lang.AFn.applyToHelper(AFn.java:154)
    at clojure.lang.Var.applyTo(Var.java:700)
    at clojure.core$apply.invoke(core.clj:624)
    at clojure.main$main_opt.invoke(main.clj:315)
    at clojure.main$main.doInvoke(main.clj:420)
    at clojure.lang.RestFn.invoke(RestFn.java:436)
    at clojure.lang.Var.invoke(Var.java:388)
    at clojure.lang.AFn.applyToHelper(AFn.java:160)
    at clojure.lang.Var.applyTo(Var.java:700)
    at clojure.main.main(main.java:37)
