### PR TITLE
add custom protoc executeable support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ your jar files. You can change this with:
 
     :proto-path "path/to/proto"
 
+You can specify custom protoc executable with:
+
+    :protoc "/usr/local/bin/protoc260"
+
 To compile all `.proto` files in this directory, just run:
 
     lein protobuf

--- a/src/leiningen/protobuf.clj
+++ b/src/leiningen/protobuf.clj
@@ -108,6 +108,10 @@
       (println "Running 'make'")
       (sh/stream-to-out (sh/proc "make" :dir srcdir) :out))))
 
+(defn protoc [project]
+  "Get :protoc argument from project."
+  (:protoc project))
+
 (defn compile-protobuf
   "Create .java and .class files from the provided .proto files."
   ([project protos]
@@ -116,7 +120,8 @@
      (let [target     (target project)
            class-dest (io/file target "classes")
            proto-dest (io/file target "proto")
-           proto-path (proto-path project)]
+           proto-path (proto-path project)
+           protoc (or (protoc project) (.getPath (protoc project)))]
        (when (or (> (modtime proto-path) (modtime dest))
                  (> (modtime proto-path) (modtime class-dest)))
          (binding [*compile-protobuf?* false]
@@ -126,7 +131,7 @@
            (.mkdirs dest)
            (extract-dependencies project proto-path protos proto-dest)
            (doseq [proto protos]
-             (let [args (into [(.getPath (protoc project)) proto
+             (let [args (into [protoc proto
                                (str "--java_out=" (.getAbsoluteFile dest)) "-I."]
                               (map #(str "-I" (.getAbsoluteFile %))
                                    [proto-dest proto-path]))]
@@ -156,8 +161,10 @@
   "Task for compiling protobuf libraries."
   [project & files]
   (let [files (or (seq files)
-                  (proto-files (proto-path project)))]
-    (build-protoc project)
+                  (proto-files (proto-path project)))
+        protoc (protoc project)]
+    (when-not protoc
+      (build-protoc project))
     (when (and (= "protobuf" (:name project)))
       (compile-google-protobuf project))
     (compile-protobuf project files)))


### PR DESCRIPTION
Sometimes it better to use local protoc compiler version instead of fresh compiled by lein-protobuf.
One of examples is CI where we might have different protoc versions and do not want to compile it every time.
This commit adds :protoc parameter to specify path to custom protoc executable.
